### PR TITLE
MinimaxEvaluator provides UpdateBoardState callback to GameBoard

### DIFF
--- a/src/bindings/xiangqigame_core.cpp
+++ b/src/bindings/xiangqigame_core.cpp
@@ -74,86 +74,35 @@ PYBIND11_MODULE(xiangqigame_core, m) {
       .export_values();
 
   //   TODO consider bindings for each allowed key bit size???
-  py::class_<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>>(
-      m,
-      "GameBoard"
-  )
+  py::class_<NewGameBoard>(m, "GameBoard")
       .def(py::init<>())
-      .def("map", &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::map)
-      .def(
-          "ExecuteMove",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::ExecuteMove,
-          "move"_a
-      )
-      .def(
-          "UndoMove",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::UndoMove,
-          "executed_move"_a
-      )
-      .def(
-          "GetAllSpacesOccupiedBy",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::
-              GetAllSpacesOccupiedBy,
-          "color"_a
-      )
-      .def(
-          "CalcFinalMovesOf",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::
-              CalcFinalMovesOf,
-          "color"_a
-      )
-      .def(
-          "IsInCheck",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::IsInCheck,
-          "color"_a
-      )
-      .def(
-          "GetType",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::GetType,
-          "space"_a
-      )
-      .def(
-          "GetColor",
-          &NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>::GetColor,
-          "space"_a
-      );
+      .def("map", &NewGameBoard::map)
+      .def("ExecuteMove", &NewGameBoard::ExecuteMove, "move"_a)
+      .def("UndoMove", &NewGameBoard::UndoMove, "executed_move"_a)
+      .def("GetAllSpacesOccupiedBy", &NewGameBoard::GetAllSpacesOccupiedBy, "color"_a)
+      .def("CalcFinalMovesOf", &NewGameBoard::CalcFinalMovesOf, "color"_a)
+      .def("IsInCheck", &NewGameBoard::IsInCheck, "color"_a)
+      .def("GetType", &NewGameBoard::GetType, "space"_a)
+      .def("GetColor", &NewGameBoard::GetColor, "space"_a);
 
   m.def("opponent_of", &opponent_of);
 
-  py::class_<MinimaxMoveEvaluator<
-      NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>,
-      PiecePoints>>(m, "MinimaxMoveEvaluator")
+  py::class_<MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>>(
+      m,
+      "MinimaxMoveEvaluator"
+  )
       .def(
-          py::init<
-              PieceColor,
-              int,
-              NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> &>(),
+          py::init<PieceColor, int, NewGameBoard &>(),
           "evaluating_player"_a,
           "starting_search_depth"_a,
           "game_board"_a
       )
       .def(
           "select_move",
-          &MinimaxMoveEvaluator<
-              NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>,
-              PiecePoints>::SelectMove
-      );
-  py::class_<RandomMoveEvaluator<
-      NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>>>(
-      m,
-      "RandomMoveEvaluator"
-  )
-      .def(
-          py::init<
-              PieceColor,
-              NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> &>(),
-          "evaluating_player"_a,
-          "game_board"_a
-      )
-      .def(
-          "select_move",
-          &RandomMoveEvaluator<
-              NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>>::
+          &MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>::
               SelectMove
       );
+  py::class_<RandomMoveEvaluator<NewGameBoard>>(m, "RandomMoveEvaluator")
+      .def(py::init<PieceColor, NewGameBoard &>(), "evaluating_player"_a, "game_board"_a)
+      .def("select_move", &RandomMoveEvaluator<NewGameBoard>::SelectMove);
 }

--- a/src/core/game_board/game_board.hpp
+++ b/src/core/game_board/game_board.hpp
@@ -12,6 +12,7 @@
 
 #include <board_components.hpp>
 #include <common.hpp>
+#include <functional>
 #include <game_board_details.hpp>
 #include <move_calculator.hpp>
 #include <move_evaluators.hpp>
@@ -22,53 +23,49 @@ using namespace board_components;
 
 // CRTP INTERFACE: GameBoard <- BoardStateSummarizer (concrete example =
 // HashCalculator)
-template <typename ConcreteBoardStateSummarizer, typename KeyType>
-class BoardStateSummarizer {
-public:
-  typedef KeyType ZobristKey_t;
-  void FullBoardStateCalc(BoardMap_t &board_map) {
-    static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementFullBoardStateCalc(
-        board_map
-    );
-  }
+// template <typename ConcreteBoardStateSummarizer, typename KeyType>
+// class BoardStateSummarizer {
+// public:
+//   typedef KeyType ZobristKey_t;
+//   void FullBoardStateCalc(BoardMap_t &board_map) {
+//     static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementFullBoardStateCalc(
+//         board_map
+//     );
+//   }
 
-  void UpdateBoardState(const ExecutedMove &move) {
-    return static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementUpdateBoardState(
-        move
-    );
-  }
+//   void UpdateBoardState(const ExecutedMove &move) {
+//     return static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementUpdateBoardState(
+//         move
+//     );
+//   }
 
-  ZobristKey_t GetState() {
-    return static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementGetState();
-  }
+//   ZobristKey_t GetState() {
+//     return static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementGetState();
+//   }
 
-  void RecordTrData(
-      int search_depth,
-      MinimaxResultType result_type,
-      BestMoves &best_moves
-  ) {
-    return static_cast<ConcreteBoardStateSummarizer *>(this)
-        ->ImplementRecordTrData(
-            search_depth,
-            result_type,
-            best_moves
-        );
-  }
+//   void RecordTrData(
+//       int search_depth,
+//       MinimaxResultType result_type,
+//       BestMoves &best_moves
+//   ) {
+//     return static_cast<ConcreteBoardStateSummarizer *>(this)
+//         ->ImplementRecordTrData(
+//             search_depth,
+//             result_type,
+//             best_moves
+//         );
+//   }
 
-  TranspositionTableSearchResult GetTrData(int search_depth) {
-    return static_cast<ConcreteBoardStateSummarizer *>(this)
-        ->ImplementGetTrData(search_depth);
-  }
-};
+//   TranspositionTableSearchResult GetTrData(int search_depth) {
+//     return static_cast<ConcreteBoardStateSummarizer *>(this)
+//         ->ImplementGetTrData(search_depth);
+//   }
+// };
 
 // Template for class NewGameBoard which implements interface
 // SpaceInfoProvider, and uses a ConcreteBoardStateSummarizer
-template <
-    typename ConcreteBoardStateSummarizerRed,
-    typename ConcreteBoardStateSummarizerBlack>
-class NewGameBoard : public SpaceInfoProvider<NewGameBoard<
-                         ConcreteBoardStateSummarizerRed,
-                         ConcreteBoardStateSummarizerBlack>> {
+
+class NewGameBoard : public SpaceInfoProvider<NewGameBoard> {
 public:
   NewGameBoard();
   NewGameBoard(const BoardMapInt_t starting_board);
@@ -77,21 +74,21 @@ public:
   }
   PieceColor ImplementGetColor(BoardSpace space) { return get_color(board_map_, space); }
   PieceType ImplementGetType(BoardSpace space) { return get_type(board_map_, space); }
-  TranspositionTableSearchResult ImplementGetEvalResult(
-      PieceColor color,
-      int search_depth
-  ) {
-    return _ImplementGetEvalResult(color, search_depth);
-  }
+  // TranspositionTableSearchResult ImplementGetEvalResult(
+  //     PieceColor color,
+  //     int search_depth
+  // ) {
+  //   return _ImplementGetEvalResult(color, search_depth);
+  // }
 
-  void ImplementRecordEvalResult(
-      PieceColor color,
-      int search_depth,
-      MinimaxResultType result_type,
-      BestMoves &best_moves
-  ) {
-    _ImplementRecordEvalResult(color, search_depth, result_type, best_moves);
-  };
+  // void ImplementRecordEvalResult(
+  //     PieceColor color,
+  //     int search_depth,
+  //     MinimaxResultType result_type,
+  //     BestMoves &best_moves
+  // ) {
+  //   _ImplementRecordEvalResult(color, search_depth, result_type, best_moves);
+  // };
 
   MoveCollection ImplementCalcFinalMovesOf(PieceColor color) {
     return _ImplementCalcFinalMovesOf(color);
@@ -107,12 +104,16 @@ public:
   };
   GamePiece GetOccupant(BoardSpace space) { return board_map_[space.rank][space.file]; };
   const BoardMap_t &map() const { return board_map_; }
+  void ImplementAttachMoveCallback(function<void(ExecutedMove)> callback) {
+    move_callbacks_.emplace_back(callback);
+  }
 
 private:
   BoardMap_t board_map_;
   MoveCalculator move_calculator_;
-  ConcreteBoardStateSummarizerRed hash_calculator_red_;
-  ConcreteBoardStateSummarizerBlack hash_calculator_black_;
+  // ConcreteBoardStateSummarizerRed hash_calculator_red_;
+  // ConcreteBoardStateSummarizerBlack hash_calculator_black_;
+  vector<function<void(ExecutedMove)>> move_callbacks_;
 
   ExecutedMove _ImplementExecuteMove(Move move) {
     auto moving_piece = GetOccupant(move.start);
@@ -135,59 +136,62 @@ private:
   }
 
   // Retrieve info for current state //////////////////////////////////////////
-  TranspositionTableSearchResult GetCurrentStateDetailsRed(int search_depth) {
-    return hash_calculator_red_.GetTrData(search_depth);
-  };
-  TranspositionTableSearchResult GetCurrentStateDetailsBlack(int search_depth) {
-    return hash_calculator_black_.GetTrData(search_depth);
-  }
-  unordered_map<PieceColor, TranspositionTableSearchResult (NewGameBoard::*)(int)>
-      state_details_dispatch_table_;
-  TranspositionTableSearchResult _ImplementGetEvalResult(
-      PieceColor color,
-      int search_depth
-  ) {
-    auto search_function = state_details_dispatch_table_.at(color);
-    return (this->*search_function)(search_depth);
-  }
+  // TranspositionTableSearchResult GetCurrentStateDetailsRed(int search_depth) {
+  //   return hash_calculator_red_.GetTrData(search_depth);
+  // };
+  // TranspositionTableSearchResult GetCurrentStateDetailsBlack(int search_depth) {
+  //   return hash_calculator_black_.GetTrData(search_depth);
+  // }
+  // unordered_map<PieceColor, TranspositionTableSearchResult (NewGameBoard::*)(int)>
+  //     state_details_dispatch_table_;
+  // TranspositionTableSearchResult _ImplementGetEvalResult(
+  //     PieceColor color,
+  //     int search_depth
+  // ) {
+  //   auto search_function = state_details_dispatch_table_.at(color);
+  //   return (this->*search_function)(search_depth);
+  // }
   //////////////////////////////////////////////////////////////////////////////
 
   // Record info for current state/////////////////////////////////////////////
-  void RecordEvalResultRed(
-      int search_depth,
-      MinimaxResultType result_type,
-      BestMoves &best_moves
-  ) {
-    hash_calculator_red_
-        .RecordTrData(search_depth, result_type, best_moves);
-  };
-  void RecordEvalResultBlack(
-      int search_depth,
-      MinimaxResultType result_type,
-      BestMoves &best_moves
-  ) {
-    hash_calculator_black_
-        .RecordTrData(search_depth, result_type, best_moves);
-  };
+  // void RecordEvalResultRed(
+  //     int search_depth,
+  //     MinimaxResultType result_type,
+  //     BestMoves &best_moves
+  // ) {
+  //   hash_calculator_red_
+  //       .RecordTrData(search_depth, result_type, best_moves);
+  // };
+  // void RecordEvalResultBlack(
+  //     int search_depth,
+  //     MinimaxResultType result_type,
+  //     BestMoves &best_moves
+  // ) {
+  //   hash_calculator_black_
+  //       .RecordTrData(search_depth, result_type, best_moves);
+  // };
 
-  unordered_map<PieceColor, void (NewGameBoard::*)(int, MinimaxResultType, BestMoves &)>
-      write_state_details_dispatch_table_;
+  // unordered_map<PieceColor, void (NewGameBoard::*)(int, MinimaxResultType, BestMoves &)>
+  //     write_state_details_dispatch_table_;
 
-  void _ImplementRecordEvalResult(
-      PieceColor color,
-      int search_depth,
-      MinimaxResultType result_type,
-      BestMoves &best_moves
-  ) {
-    auto record_function = write_state_details_dispatch_table_.at(color);
-    (this->*record_function)(search_depth, result_type, best_moves);
-  }
+  // void _ImplementRecordEvalResult(
+  //     PieceColor color,
+  //     int search_depth,
+  //     MinimaxResultType result_type,
+  //     BestMoves &best_moves
+  // ) {
+  //   auto record_function = write_state_details_dispatch_table_.at(color);
+  //   (this->*record_function)(search_depth, result_type, best_moves);
+  // }
   /////////////////////////////////////////////////////////////////////////////////
 
   std::map<PieceColor, vector<ExecutedMove>> move_log_;
   void UpdateHashCalculator(ExecutedMove executed_move) {
-    hash_calculator_red_.UpdateBoardState(executed_move);
-    hash_calculator_black_.UpdateBoardState(executed_move);
+    // hash_calculator_red_.UpdateBoardState(executed_move);
+    // hash_calculator_black_.UpdateBoardState(executed_move);
+    for (const auto &callback : move_callbacks_) {
+      callback(executed_move);
+    }
   };
   void SetOccupant(BoardSpace space, GamePiece piece) {
     board_map_[space.rank][space.file] = piece;

--- a/src/core/game_board/game_board.tpp
+++ b/src/core/game_board/game_board.tpp
@@ -30,36 +30,27 @@ BoardMap_t int_board_to_game_pieces(const BoardMapInt_t int_board) {
   return game_piece_board;
 }
 
-template <
-    typename ConcreteBoardStateSummarizerRed,
-    typename ConcreteBoardStateSummarizerBlack>
-NewGameBoard<
-    ConcreteBoardStateSummarizerRed,
-    ConcreteBoardStateSummarizerBlack>::NewGameBoard(const BoardMapInt_t
+NewGameBoard::NewGameBoard(const BoardMapInt_t
                                                          board_array)
     : board_map_{int_board_to_game_pieces(board_array)}
     , move_calculator_{MoveCalculator()} {
 
-  hash_calculator_red_.FullBoardStateCalc(board_map_);
-  hash_calculator_black_.FullBoardStateCalc(board_map_);
+  // hash_calculator_red_.FullBoardStateCalc(board_map_);
+  // hash_calculator_black_.FullBoardStateCalc(board_map_);
 
-  state_details_dispatch_table_[PieceColor::kBlk] =
-      &NewGameBoard::GetCurrentStateDetailsBlack;
-  state_details_dispatch_table_[PieceColor::kRed] =
-      &NewGameBoard::GetCurrentStateDetailsRed;
+  // state_details_dispatch_table_[PieceColor::kBlk] =
+  //     &NewGameBoard::GetCurrentStateDetailsBlack;
+  // state_details_dispatch_table_[PieceColor::kRed] =
+  //     &NewGameBoard::GetCurrentStateDetailsRed;
 
-  write_state_details_dispatch_table_[PieceColor::kBlk] =
-      &NewGameBoard::RecordEvalResultBlack;
-  write_state_details_dispatch_table_[PieceColor::kRed] =
-      &NewGameBoard::RecordEvalResultRed;
+  // write_state_details_dispatch_table_[PieceColor::kBlk] =
+  //     &NewGameBoard::RecordEvalResultBlack;
+  // write_state_details_dispatch_table_[PieceColor::kRed] =
+  //     &NewGameBoard::RecordEvalResultRed;
 }
 
-template <
-    typename ConcreteBoardStateSummarizerRed,
-    typename ConcreteBoardStateSummarizerBlack>
-NewGameBoard<
-    ConcreteBoardStateSummarizerRed,
-    ConcreteBoardStateSummarizerBlack>::NewGameBoard()
+
+NewGameBoard::NewGameBoard()
     : NewGameBoard(kStartingBoard) {}
 
 #endif

--- a/src/core/move_evaluators/move_evaluators.hpp
+++ b/src/core/move_evaluators/move_evaluators.hpp
@@ -37,23 +37,6 @@ public:
     return static_cast<ConcreteSpaceInfoProvider *>(this)->ImplementGetType(space);
   }
 
-  // TranspositionTableSearchResult GetEvalResult(PieceColor color, int search_depth) {
-  //   return static_cast<ConcreteSpaceInfoProvider *>(this)->ImplementGetEvalResult(
-  //       color,
-  //       search_depth
-  //   );
-  // }
-
-  // void RecordEvalResult(
-  //     PieceColor color,
-  //     int search_depth,
-  //     MinimaxResultType result_type,
-  //     BestMoves &best_moves
-  // ) {
-  //   return static_cast<ConcreteSpaceInfoProvider *>(this)
-  //       ->ImplementRecordEvalResult(color, search_depth, result_type, best_moves);
-  // }
-
   MoveCollection CalcFinalMovesOf(PieceColor color) {
     return static_cast<ConcreteSpaceInfoProvider *>(this)->ImplementCalcFinalMovesOf(
         color
@@ -74,9 +57,10 @@ public:
   }
 };
 
-// CRTP Interface: Evaluator <- BoardStateSummarizer
+// CRTP Interface: Evaluator <- BoardStateSummarizer (e.g. HashCalculator)
 template <typename ConcreteBoardStateSummarizer, typename KeyType>
 class BoardStateSummarizer {
+public:
   typedef KeyType ZobristKey_t;
   void FullBoardStateCalc(BoardMap_t &board_map) {
     static_cast<ConcreteBoardStateSummarizer *>(this)->ImplementFullBoardStateCalc(
@@ -109,8 +93,6 @@ class BoardStateSummarizer {
     );
   }
 };
-
-
 
 // CRTP Interface: Evaluator <- GamePoints
 template <typename ConcretePieceValueProvider>
@@ -150,10 +132,14 @@ public:
 //    implements PieceValueProvider
 // Uses minimax algorithm with alpha-beta pruning to select a move for
 // evaluating_player_.
-template <typename ConcreteSpaceInfoProvider, typename ConcretePieceValueProvider>
-class MinimaxMoveEvaluator
-    : public MoveEvaluatorInterface<
-          MinimaxMoveEvaluator<ConcreteSpaceInfoProvider, ConcretePieceValueProvider>> {
+template <
+    typename ConcreteSpaceInfoProvider,
+    typename ConcreteBoardStateSummarizer,
+    typename ConcretePieceValueProvider>
+class MinimaxMoveEvaluator : public MoveEvaluatorInterface<MinimaxMoveEvaluator<
+                                 ConcreteSpaceInfoProvider,
+                                 ConcreteBoardStateSummarizer,
+                                 ConcretePieceValueProvider>> {
 
 public:
   MinimaxMoveEvaluator(
@@ -175,6 +161,7 @@ public:
 private:
   PieceColor evaluating_player_;
   ConcretePieceValueProvider game_position_points_;
+  ConcreteBoardStateSummarizer hash_calculator_;
   ConcreteSpaceInfoProvider &game_board_;
   BestMoves EvaluateNonWinLeaf(PieceColor cur_player);
   BestMoves EvaluateEndOfGameLeaf(PieceColor cur_player);

--- a/tests/core/game_board_test.cpp
+++ b/tests/core/game_board_test.cpp
@@ -6,7 +6,7 @@
 
 class GameBoardTest : public ::testing::Test {
 protected:
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> gb_;
+  NewGameBoard gb_;
   const BoardMapInt_t kRepeatMoveTestBoard{{
       {0, 0, 0, 1, 0, 0, 0, 0, 0},
       {0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -101,9 +101,7 @@ TEST_F(GameBoardTest, ExecuteMoveWithAttachedHashCalculators) {
 }
 
 TEST_F(GameBoardTest, ProhibitsTripleRepeatMovePeriod_02) {
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> late_game_board(
-      kRepeatMoveTestBoard
-  );
+  NewGameBoard late_game_board(kRepeatMoveTestBoard);
   auto red_king_position_a = BoardSpace{9, 4};
   auto red_king_position_b = BoardSpace{9, 3};
 
@@ -121,7 +119,7 @@ TEST_F(GameBoardTest, ProhibitsTripleRepeatMovePeriod_02) {
 }
 
 TEST_F(GameBoardTest, ProhibitsTripleRepeatMovePeriod_03) {
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> late_game_board(
+  NewGameBoard late_game_board(
       kRepeatMoveTestBoard
   );
   auto red_king_position_a = BoardSpace{9, 4};

--- a/tests/core/minimax_evaluator_test.cpp
+++ b/tests/core/minimax_evaluator_test.cpp
@@ -25,9 +25,8 @@ protected:
 TEST_F(RandomEvaluatorTest, TestStartingMoveSelection) {
   int num_first_move_selections = 10;
 
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> starting_board;
-  RandomMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>>
-      red_evaluator{PieceColor::kRed, starting_board};
+  NewGameBoard starting_board;
+  RandomMoveEvaluator<NewGameBoard> red_evaluator{PieceColor::kRed, starting_board};
 
   std::set<Move, bool (*)(const Move &, const Move &)> move_set(moveComparator);
 
@@ -60,35 +59,29 @@ protected:
       {5, 0, 0, 0, 0, 0, 0, 0, 0},
       {0, 0, 0, 0, -1, 0, 0, 0, 0},
   }};
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> late_game_board_{
-      kLateGameBoardMap
-  };
+  NewGameBoard late_game_board_{kLateGameBoardMap};
 
   const int standard_search_depth = 4;
 };
 
 TEST_F(MinimaxEvaluatorTest, TestConstructorsWithDefaultPiecePoints) {
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> starting_board;
-  MinimaxMoveEvaluator<
-      NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>,
-      PiecePoints>
+  NewGameBoard starting_board;
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       red_evaluator{PieceColor::kRed, standard_search_depth, starting_board};
-  MinimaxMoveEvaluator<
-      NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>,
-      PiecePoints>
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       black_evaluator{PieceColor::kBlk, standard_search_depth, starting_board};
 }
 
 TEST_F(MinimaxEvaluatorTest, TestConstructorsWithImportedPiecePoints) {
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> starting_board;
-  MinimaxMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>, PiecePoints>
+  NewGameBoard starting_board;
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       red_evaluator{
           PieceColor::kRed,
           standard_search_depth,
           starting_board,
           imported_piece_points
       };
-  MinimaxMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>, PiecePoints>
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       black_evaluator{
           PieceColor::kBlk,
           standard_search_depth,
@@ -98,8 +91,8 @@ TEST_F(MinimaxEvaluatorTest, TestConstructorsWithImportedPiecePoints) {
 }
 
 TEST_F(MinimaxEvaluatorTest, RedStartingMoveSelection) {
-  NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>> starting_board;
-  MinimaxMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>, PiecePoints>
+  NewGameBoard starting_board;
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       red_evaluator{
           PieceColor::kRed,
           standard_search_depth,
@@ -118,7 +111,7 @@ TEST_F(MinimaxEvaluatorTest, RedStartingMoveSelection) {
 
 TEST_F(MinimaxEvaluatorTest, EndOfGameSelectorTest) {
 
-  MinimaxMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>, PiecePoints>
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       black_evaluator{
           PieceColor::kBlk,
           standard_search_depth,
@@ -134,10 +127,10 @@ TEST_F(MinimaxEvaluatorTest, EndOfGameSelectorTest) {
 }
 
 TEST_F(MinimaxEvaluatorTest, PlayGame) {
-  NewGameBoard<HashCalculator<uint64_t>,HashCalculator<uint64_t>> game_board;
+  NewGameBoard game_board;
 
   int red_search_depth{2};
-  MinimaxMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>, PiecePoints>
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       red_evaluator{
           PieceColor::kRed,
           red_search_depth,
@@ -146,7 +139,7 @@ TEST_F(MinimaxEvaluatorTest, PlayGame) {
       };
 
   int black_search_depth{3};
-  MinimaxMoveEvaluator<NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>, PiecePoints>
+  MinimaxMoveEvaluator<NewGameBoard, HashCalculator<uint64_t>, PiecePoints>
       black_evaluator{
           PieceColor::kBlk,
           black_search_depth,

--- a/tests/core/move_calc_timer.cpp
+++ b/tests/core/move_calc_timer.cpp
@@ -7,7 +7,7 @@ using namespace std::chrono;
 
 int main() {
   auto my_game_board =
-      NewGameBoard<HashCalculator<uint64_t>, HashCalculator<uint64_t>>();
+      NewGameBoard();
 
   auto start = high_resolution_clock::now();
 


### PR DESCRIPTION
HashCalculator is now a member of MinimaxMoveEvaluator and not a member of GameBoard. MinimaxMoveEvaluator attaches an UpdateBoardState callback to GameBoard to run any time it executes or un-does a move. This change simplifies class definitions (less template nesting) since NewGameBoard is no longer a template class and does not need to know the integer type used for HashCalculator keys. 