### PR TITLE
Python UI: flip board rank order

### DIFF
--- a/src/core/game_board/game_board.hpp
+++ b/src/core/game_board/game_board.hpp
@@ -58,7 +58,7 @@ public:
 private:
   BoardMap_t board_map_;
   MoveCalculator move_calculator_;
-  vector<function<void(ExecutedMove)>> move_callbacks_;
+  vector<function<void(ExecutedMove)>> move_callbacks_;  // hash calc functs go here
   std::map<PieceColor, vector<ExecutedMove>> move_log_;
 
   ExecutedMove _ImplementExecuteMove(Move move) {

--- a/src/xiangqigame/move_translator.py
+++ b/src/xiangqigame/move_translator.py
@@ -19,14 +19,14 @@ def algebraic_space_to_boardspace(algebraic_space: str) -> BoardSpace:
     alg_column = algebraic_space[0]
     file = ord(alg_column) - ord('a')
     alg_row = algebraic_space[1:]
-    rank = int(alg_row) - 1
+    rank = 10 - int(alg_row)
 
     return BoardSpace(rank=rank, file=file)
 
 
 def boardspace_to_algebraic_space(board_space: BoardSpace) -> str:
     alg_column = chr(board_space.file + ord('a'))
-    alg_row = str(board_space.rank + 1)
+    alg_row = str(10 - board_space.rank)
     return f"{alg_column}{alg_row}"
 
 

--- a/src/xiangqigame/terminal_output.py
+++ b/src/xiangqigame/terminal_output.py
@@ -79,7 +79,7 @@ class TerminalStatusReporter(GameStatusReporter):
             for row in range(len(board.map()))
         ]
         for row_index in range(len(board_list)):
-            board_list[row_index].insert(0, f" {str(row_index + 1)}\t")
+            board_list[row_index].insert(0, f" {str(10 - row_index)}\t")
         board_list.insert(0, file_labels)
         board_list = ["".join(row) for row in board_list]
 

--- a/tests/python/alg_rank_modifier.py
+++ b/tests/python/alg_rank_modifier.py
@@ -1,0 +1,73 @@
+import re
+import pprint
+from typing import List
+
+
+def transform_moves(moves: List[str]) -> List[str]:
+    """
+    Transforms a list of Xiangqi algebraic notation moves by correcting the
+    rank ordering. The ranks in the input are given with rank 1 on the black
+    side, which is incorrect. This function adjusts the ranks so that rank 1
+    is on the red side, which is the conventional ordering in Xiangqi.
+
+    :param moves: A list of moves in algebraic notation, where each move is
+                  a string with file (letter) and rank (number) pairs.
+    :type moves: list of str
+    :return: A new list with ranks corrected to the proper ordering.
+    """
+    transformed_moves = []
+
+    # Regular expression to match letters followed by numbers
+    pattern = re.compile(r"([a-zA-Z]+)(\d+)")
+
+    for move in moves:
+        # Split the move into its two components
+        parts = move.split(", ")
+        transformed_parts = []
+
+        for part in parts:
+            # Substitute each part's numeric value
+            new_part = pattern.sub(
+                lambda m: f"{m.group(1)}{11 - int(m.group(2))}", part
+            )
+            transformed_parts.append(new_part)
+
+        # Join the transformed parts back
+        transformed_move = ", ".join(transformed_parts)
+        transformed_moves.append(transformed_move)
+
+    return transformed_moves
+
+
+if __name__ == "__main__":
+    original_move_list = [
+        "a7, a6",
+        "a4, a5",
+        "a6, a5",
+        "b3, b5",
+        "a5, b5",
+        "c4, c5",
+        "b5, c5",
+        "c1, a3",
+        "e7, e6",
+        "e4, e5",
+        "e6, e5",
+        "h1, g3",
+        "g10, e8",
+        "g3, e4",
+        "e5, e4",
+        "g1, i3",
+        "a10, a3",
+        "e1, e2",
+        "a3, e3",
+        "e2, f2",
+        "i10, i9",
+        "f1, e2",
+        "e3, e2",
+        "f2, f3",
+        "i9, f9",
+    ]
+
+    updated_move_list = transform_moves(original_move_list)
+
+    pprint.pprint(updated_move_list)

--- a/tests/python/test_scripted_game.py
+++ b/tests/python/test_scripted_game.py
@@ -10,31 +10,31 @@ import unittest
 class ScriptedGameTests(unittest.TestCase):
 
     scripted_moves = [
-        "a7, a6",
         "a4, a5",
-        "a6, a5",
-        "b3, b5",
-        "a5, b5",
-        "c4, c5",
-        "b5, c5",
-        "c1, a3",
-        "e7, e6",
+        "a7, a6",
+        "a5, a6",
+        "b8, b6",
+        "a6, b6",
+        "c7, c6",
+        "b6, c6",
+        "c10, a8",
         "e4, e5",
-        "e6, e5",
-        "h1, g3",
-        "g10, e8",
-        "g3, e4",
-        "e5, e4",
-        "g1, i3",
-        "a10, a3",
-        "e1, e2",
-        "a3, e3",
-        "e2, f2",
-        "i10, i9",
-        "f1, e2",
-        "e3, e2",
-        "f2, f3",
-        "i9, f9",
+        "e7, e6",
+        "e5, e6",
+        "h10, g8",
+        "g1, e3",
+        "g8, e7",
+        "e6, e7",
+        "g10, i8",
+        "a1, a8",
+        "e10, e9",
+        "a8, e8",
+        "e9, f9",
+        "i1, i2",
+        "f10, e9",
+        "e8, e9",
+        "f9, f8",
+        "i2, f2",
     ]
 
     @staticmethod
@@ -42,9 +42,14 @@ class ScriptedGameTests(unittest.TestCase):
         red_moves, black_moves = move_list[::2], move_list[1::2]
         game_board = GameBoard()
         red_player = ScriptedPlayer(color=PieceColor.kRed, move_list=red_moves)
-        black_player = ScriptedPlayer(color=PieceColor.kBlk, move_list=black_moves)
+        black_player = ScriptedPlayer(
+            color=PieceColor.kBlk, move_list=black_moves
+        )
         game = Game(
-            players={PieceColor.kRed: red_player, PieceColor.kBlk: black_player},
+            players={
+                PieceColor.kRed: red_player,
+                PieceColor.kBlk: black_player,
+            },
             game_board=game_board,
         )
         game.play()


### PR DESCRIPTION
Change order of board ranks in Python UI so that rank 1 is on Red's side of board. This is the order used in conventional algebraic notation.